### PR TITLE
Pridejau NoteRepository ir NoteController testus

### DIFF
--- a/Collibri.Tests/Controllers/NoteControllerTestData.cs
+++ b/Collibri.Tests/Controllers/NoteControllerTestData.cs
@@ -1,0 +1,53 @@
+using System.Net.Sockets;
+using Collibri.Models.Notes;
+
+namespace Collibri.Tests.Controllers
+{
+    public class CreateNoteTestData : TheoryData<Note, Note?, int?>
+    {
+        public CreateNoteTestData()
+        {
+            Add(new Note(111, 222, Guid.NewGuid(), "NoteName", "NoteText", "NoteAuthor"), 
+                new Note(111, 222, Guid.NewGuid(), "NoteName", "NoteText", "NoteAuthor", 1), 
+                200);
+            
+            Add(new Note(111, 222, Guid.NewGuid(), "NoteName", "NoteText", "NoteAuthor"),
+                null,
+                409);
+        }
+    }
+
+    public class GetAllNotesInSectionTestData : TheoryData<int, IEnumerable<Note>>
+    {
+        public GetAllNotesInSectionTestData()
+        {
+            Add(1,
+                new List<Note>
+                {
+                    new Note(1, 10, Guid.NewGuid(), "NoteName", "NoteText", "NoteAuthor"),
+                    new Note(1, 10, Guid.NewGuid(), "NoteName2", "NoteText2", "NoteAuthor2")
+                }.AsEnumerable()
+            );
+            
+            Add(1, new List<Note>().AsEnumerable());
+        }
+    }
+    
+    public class UpdateNoteTestData : TheoryData<Note, Note?, int, int>
+    {
+        public UpdateNoteTestData()
+        {
+            Add(new Note(1, 2, Guid.NewGuid(), "Old Name", "Old Text", "author", 1111),
+                new Note(1, 2, Guid.NewGuid(), "New Name", "New Text", "author", 1111),
+                1111,
+                200
+            );
+            
+            Add(new Note(1, 2, Guid.NewGuid(), "Old Name", "Old Text", "author", 1111), 
+                null, 
+                2222, 
+                409);
+        }
+    }
+}
+

--- a/Collibri.Tests/Controllers/NoteControllerTests.cs
+++ b/Collibri.Tests/Controllers/NoteControllerTests.cs
@@ -1,0 +1,81 @@
+using Collibri.Controllers;
+using Collibri.Models.Notes;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Collibri.Tests.Controllers
+{
+    public class NoteControllerTests
+    {
+        [Theory]
+        [ClassData(typeof(CreateNoteTestData))]
+        public void CreateNoteTest(
+            Note note,
+            Note? result,
+            int? statusCode    
+            )
+        { 
+            var repository = new Mock<INoteRepository>(); 
+            var controller = new NoteController(repository.Object);
+            repository.Setup(x => x.CreateNote(note)).Returns(result);
+
+            var actual = controller.CreateNote(note);
+
+            if (result == null)
+            {
+                Assert.IsType<ConflictResult>(actual);
+                Assert.Equal(statusCode, ((ConflictResult)actual).StatusCode);
+            }
+            else
+            {
+                Assert.IsType<OkObjectResult>(actual);
+                Assert.Equal(statusCode, ((OkObjectResult)actual).StatusCode);
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(GetAllNotesInSectionTestData))]
+        public void GetAllNotesInSectionTest(
+            int id,
+            IEnumerable<Note> result
+            )
+        {
+            var repository = new Mock<INoteRepository>(); 
+            var controller = new NoteController(repository.Object);
+            repository.Setup(x => x.GetAllNotesInSection(id)).Returns(result);
+
+            var actual = controller.GetAllNotesInSection(id) as ObjectResult;
+
+            Assert.IsType<List<Note>>(actual?.Value);
+            Assert.Equal(result, actual.Value);
+        }
+        
+        [Theory]
+        [ClassData(typeof(UpdateNoteTestData))]
+        public void UpdateNoteTest(
+            Note note,
+            Note? updatedNote,
+            int id,
+            int statusCode
+            )
+        {
+            var repository = new Mock<INoteRepository>();
+            var controller = new NoteController(repository.Object);
+            repository.Setup(x => x.UpdateNote(note, id)).Returns(updatedNote);
+            
+            var actual = controller.UpdateNote(note, id);
+            
+            if (updatedNote == null)
+            {
+                Assert.IsType<ConflictResult>(actual);
+                Assert.Equal(statusCode, ((ConflictResult)actual).StatusCode);
+            }
+            else
+            {
+                Assert.IsType<OkObjectResult>(actual);
+                Assert.Equal(statusCode, ((OkObjectResult)actual).StatusCode);
+                Assert.Equal(updatedNote, ((ObjectResult)actual).Value);
+            }
+        }
+    }
+}
+

--- a/Collibri.Tests/Models/Notes/NoteRepositoryTestData.cs
+++ b/Collibri.Tests/Models/Notes/NoteRepositoryTestData.cs
@@ -1,0 +1,91 @@
+using System.Net.Sockets;
+using Collibri.Models.Notes;
+
+namespace Collibri.Tests.Models.Notes
+{
+    public class CreateNoteTestData : TheoryData<Note, Note?, List<Note>>
+    {
+        public CreateNoteTestData()
+        {
+            Add(new Note(111, 222, Guid.NewGuid(), "testNote1", "testText1", "author1"), null,
+                new List<Note>
+                {
+                    new Note(111, 222, Guid.NewGuid(),"existingNote", "text", "existingAuthor"),
+                    new Note(112, 223, Guid.NewGuid(),"existingNote2", "text", "existingAuthor2")
+                }
+            );
+            
+            Add(new Note(111, 222, Guid.NewGuid(),"testNote1", "testText1", "author1"), null,
+                new List<Note>
+                {
+                    new Note(112, 200, Guid.NewGuid(),"testNote1", "text", "existingAuthor"),
+                    new Note(112, 223, Guid.NewGuid(),"existingNote2", "text", "existingAuthor2")
+                }
+            );
+            Add(new Note(111, 222, Guid.NewGuid(),"testNote1", "testText1", "author1"), null,
+                new List<Note>
+                {
+                    new Note(111, 222, Guid.NewGuid(),"existingNote", "text", "existingAuthor"),
+                    new Note(111, 222, Guid.NewGuid(),"testNote1", "text", "existingAuthor2")
+                }
+            );
+        }
+    }
+
+    public class GetAllNotesInSectionTestData : TheoryData<int, List<Note>>
+    {
+        public GetAllNotesInSectionTestData()
+        {
+            Add(111,
+                new List<Note>
+                {
+                    new Note(111, 222, Guid.NewGuid(),"existingNote1", "text", "existingAuthor1"),
+                    new Note(112, 222, Guid.NewGuid(),"existingNote2", "text", "existingAuthor2"),
+                    new Note(111, 223, Guid.NewGuid(),"existingNote3", "text", "existingAuthor3")
+                }
+            );
+            Add(101,
+                new List<Note>
+                {
+                    new Note(111, 222, Guid.NewGuid(),"existingNote1", "text", "existingAuthor1"),
+                    new Note(112, 222, Guid.NewGuid(),"existingNote2", "text", "existingAuthor2"),
+                    new Note(111, 223, Guid.NewGuid(),"existingNote3", "text", "existingAuthor3")
+                }
+            );
+            Add(111,
+                new List<Note>
+                {
+                    new Note(111, 222, Guid.NewGuid(),"existingNote1", "text", "existingAuthor1"),
+                    new Note(111, 222, Guid.NewGuid(),"existingNote2", "text", "existingAuthor2"),
+                    new Note(111, 223, Guid.NewGuid(),"existingNote3", "text", "existingAuthor3")
+                }
+            );
+        }
+    }
+
+    public class DeleteNoteTestData : TheoryData<int, Note?, List<Note>>
+    {
+        private readonly Note? _expected1 = new Note(111, 222, Guid.NewGuid(),"existingNote1", "text", "existingAuthor1", 1010);
+        
+        public DeleteNoteTestData()
+        {
+            Add(1010, _expected1,
+                new List<Note>
+                {
+                    _expected1,
+                    new Note(112, 222, Guid.NewGuid(),"existingNote2", "text", "existingAuthor2", 2020),
+                    new Note(111, 223, Guid.NewGuid(),"existingNote3", "text", "existingAuthor3", 3030)
+                }
+            );
+            Add(4040, null,
+                new List<Note>
+                {
+                    new Note(111, 222, Guid.NewGuid(),"existingNote1", "text", "existingAuthor1", 1010),
+                    new Note(112, 222, Guid.NewGuid(),"existingNote2", "text", "existingAuthor2", 2020),
+                    new Note(111, 223, Guid.NewGuid(),"existingNote3", "text", "existingAuthor3", 3030)
+                }
+            );
+        }
+    }
+}
+

--- a/Collibri.Tests/Models/Notes/NoteRepositoryTests.cs
+++ b/Collibri.Tests/Models/Notes/NoteRepositoryTests.cs
@@ -1,0 +1,66 @@
+using Collibri.Models.DataHandling;
+using Collibri.Models.Notes;
+using Collibri.Models.Sections;
+
+namespace Collibri.Tests.Models.Notes
+{
+    public class NoteRepositoryTests
+    {
+        [Theory]
+        [ClassData(typeof(CreateNoteTestData))]
+        public void CreateNoteTest(
+            Note note,
+            Note? expected,
+            List<Note> list
+            )
+        {
+            var dataHandler = new Mock<IDataHandler>();
+            var repository = new NoteRepository(dataHandler.Object);
+            dataHandler.Setup(x => x.GetAllItems<Note>(ModelType.Notes)).Returns(list);
+            
+            var actual = repository.CreateNote(note);
+            if (actual != null)
+            {
+                expected = note;
+                expected.Id = note.Id;
+            }
+            
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [ClassData(typeof(GetAllNotesInSectionTestData))]
+        public void GetAllNotesInSectionTest(
+            int sectionId,
+            List<Note> list
+            )
+        {
+            var dataHandler = new Mock<IDataHandler>();
+            var repository = new NoteRepository(dataHandler.Object);
+            dataHandler.Setup(x => x.GetAllItems<Note>(ModelType.Notes)).Returns(list);
+
+            var actual = repository.GetAllNotesInSection(sectionId);
+            
+            Assert.Equal(list.Where(item => item.SectionId == sectionId).AsEnumerable(), actual);
+        }
+
+        [Theory]
+        [ClassData(typeof(DeleteNoteTestData))]
+        public void DeleteNoteTest(
+            int id,
+            Note? expected,
+            List<Note> list
+        )
+        {
+            var dataHandler = new Mock<IDataHandler>();
+            var repository = new NoteRepository(dataHandler.Object);
+            dataHandler.Setup(x => x.GetAllItems<Note>(ModelType.Notes)).Returns(list);
+
+            var actual = repository.DeleteNote(id);
+            
+            Assert.Equal(expected, actual);
+            Assert.DoesNotContain(actual, list);
+        }
+    }
+}
+

--- a/Collibri/Models/Notes/Note.cs
+++ b/Collibri/Models/Notes/Note.cs
@@ -11,8 +11,8 @@
         public int Id { get; set; }
         public DateTime CreationDate { get; set; }
         public DateTime LastUpdatedDate { get; set; }
-
-        public Note(int sectionId, int roomId, string name, Guid postId, string text, string author)
+        
+        public Note(int sectionId, int roomId, Guid postId, string name, string text, string author, int id = 0)
         {
             this.Name = name;
             this.Text = text;
@@ -20,6 +20,7 @@
             this.SectionId = sectionId;
             this.RoomId = roomId;
             this.PostId = postId;
+            this.Id = id;
         }
     }
 }


### PR DESCRIPTION
NoteRepository ir NoteController testai. Paprasti, basically tokie patys kaip ir kitu modeliu. Pridejau i Note constructoriu optional id argumenta, kuri testuose vietom naudojau ir vietom ne. Tai cia kaip ir tas reikalavimas gal ir igyvendintas, tiesiog nezinau kiek cia is tiesu yra prasminga, nes ta pati butu galima padaryti su antru constructoriu ir gal id defaultiskai nereiketu i tapati setint, nu bet kaip ir tik testuose naudojama o per repository sukuriant randomizina tai gal nesvarbu.