### PR TITLE
Multiplatform path FileRepository ir failų testuose

### DIFF
--- a/Collibri.Tests/Models/Files/FileRepositoryTestData.cs
+++ b/Collibri.Tests/Models/Files/FileRepositoryTestData.cs
@@ -9,7 +9,8 @@ namespace Collibri.Tests.Models.Files
     {
         public CreateFileData()
         {
-            var path = FileTestHelper.GetPath("00000000000000000000000000000000");
+            var postId = "00000000000000000000000000000000";
+            var path = FileTestHelper.GetPath(postId);
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
             {
                 { path + "\\textFile.txt", new MockFileData("Text file test data") },
@@ -17,21 +18,17 @@ namespace Collibri.Tests.Models.Files
                 { path + "\\pngFile.png", new MockFileData(new byte[] { 0x12, 0x34, 0x56, 0xd2 }) }
             });
             
-            Add(fileSystem, FileTestHelper.CreateTestFormFile("textFile1.txt", "Text file test data"),
-                "00000000000000000000000000000000",
-                new File(path + "\\textFile1.txt", Guid.Parse("00000000000000000000000000000000")));
+            Add(fileSystem, FileTestHelper.CreateTestFormFile("textFile1.txt", "Text file test data"), postId,
+                new File(path + "\\textFile1.txt", Guid.Parse(postId)));
             // Should return null
-            Add(fileSystem, FileTestHelper.CreateTestFormFile("textFile.txt", "Text file test data"),
-                "00000000000000000000000000000000",
+            Add(fileSystem, FileTestHelper.CreateTestFormFile("textFile.txt", "Text file test data"), postId,
                 null);
             // No extension
-            Add(fileSystem, FileTestHelper.CreateTestFormFile("textFile", "Text file test data"),
-                "00000000000000000000000000000000",
-                new File(path + "\\textFile", Guid.Parse("00000000000000000000000000000000")));
+            Add(fileSystem, FileTestHelper.CreateTestFormFile("textFile", "Text file test data"), postId,
+                new File(path + "\\textFile", Guid.Parse(postId)));
             Add(fileSystem, FileTestHelper.CreateTestFormFile("pngFile2.png",
-                    System.Text.Encoding.UTF8.GetString(new byte[] { 0x12, 0x34, 0x56, 0xd2 })),
-                "00000000000000000000000000000000",
-                new File(path + "\\pngFile2.png", Guid.Parse("00000000000000000000000000000000")));
+                    System.Text.Encoding.UTF8.GetString(new byte[] { 0x12, 0x34, 0x56, 0xd2 })), postId,
+                new File(path + "\\pngFile2.png", Guid.Parse(postId)));
         }
     }
 
@@ -39,7 +36,8 @@ namespace Collibri.Tests.Models.Files
     {
         public DeleteFileData()
         {
-            var path = FileTestHelper.GetPath("00000000000000000000000000000001");
+            var postId = "00000000000000000000000000000001";
+            var path = FileTestHelper.GetPath(postId);
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
             {
                 { path + "\\textFile.txt", new MockFileData("Text file test data") },
@@ -47,13 +45,11 @@ namespace Collibri.Tests.Models.Files
                 { path + "\\pngFile.png", new MockFileData(new byte[] { 0x12, 0x34, 0x56, 0xd2 }) },
                 { path + "\\noExtension", new MockFileData("No extension file test data") }
             });
-            Add(fileSystem, "textFile.txt", "00000000000000000000000000000001",
-                new File(path + "\\textFile.txt", Guid.Parse("00000000000000000000000000000001")));
+            Add(fileSystem, "textFile.txt", postId, new File(path + "\\textFile.txt", Guid.Parse(postId)));
             // Should return null
-            Add(fileSystem, "noFile.txt", "00000000000000000000000000000001", null);
+            Add(fileSystem, "noFile.txt", postId, null);
             // No extension
-            Add(fileSystem, "noExtension", "00000000000000000000000000000001",
-                new File(path + "\\noExtension", Guid.Parse("00000000000000000000000000000001")));
+            Add(fileSystem, "noExtension", postId, new File(path + "\\noExtension", Guid.Parse(postId)));
         }
     }
 
@@ -61,7 +57,8 @@ namespace Collibri.Tests.Models.Files
     {
         public GetFileData()
         {
-            var path = FileTestHelper.GetPath("00000000000000000000000000000002");
+            var postId = "00000000000000000000000000000002";
+            var path = FileTestHelper.GetPath(postId);
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
             {
                 { path + "\\textFile.txt", new MockFileData("Text file test data") },
@@ -69,13 +66,13 @@ namespace Collibri.Tests.Models.Files
                 { path + "\\pngFile.png", new MockFileData(new byte[] { 0x12, 0x34, 0x56, 0xd2 }) },
                 { path + "\\noExtension", new MockFileData("No extension file test data") }
             });
-            Add(fileSystem, "textFile.txt", "00000000000000000000000000000002",
+            Add(fileSystem, "textFile.txt", postId,
                 FileTestHelper.CreateTestFileStreamResult(fileSystem, path, "textFile.txt"));
             // Should return null
-            Add(fileSystem, "noFile.txt", "00000000000000000000000000000002", null);
-            Add(fileSystem, "noExtension", "00000000000000000000000000000002",
+            Add(fileSystem, "noFile.txt", postId, null);
+            Add(fileSystem, "noExtension", postId,
                 FileTestHelper.CreateTestFileStreamResult(fileSystem, path, "noExtension"));
-            Add(fileSystem, "pngFile.png", "00000000000000000000000000000002",
+            Add(fileSystem, "pngFile.png", postId,
                 FileTestHelper.CreateTestFileStreamResult(fileSystem, path, "pngFile.png"));
         }
     }
@@ -84,7 +81,8 @@ namespace Collibri.Tests.Models.Files
     {
         public UpdateFileNameData()
         {
-            var path = FileTestHelper.GetPath("00000000000000000000000000000003");
+            var postId = "00000000000000000000000000000003";
+            var path = FileTestHelper.GetPath(postId);
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
             {
                 { path + "\\textFile.txt", new MockFileData("Text file test data") },
@@ -92,10 +90,10 @@ namespace Collibri.Tests.Models.Files
                 { path + "\\pngFile.png", new MockFileData(new byte[] { 0x12, 0x34, 0x56, 0xd2 }) },
                 { path + "\\noExtension", new MockFileData("No extension file test data") }
             });
-            Add(fileSystem, "textFile.txt", "00000000000000000000000000000003", "anotherTextFile.txt",
-                new File(path + "\\anotherTextFile.txt", Guid.Parse("00000000000000000000000000000003")));
+            Add(fileSystem, "textFile.txt", postId, "anotherTextFile.txt",
+                new File(path + "\\anotherTextFile.txt", Guid.Parse(postId)));
             // Should return null
-            Add(fileSystem, "noFile.txt", "00000000000000000000000000000003", "anotherTextFile.txt", null);
+            Add(fileSystem, "noFile.txt", postId, "anotherTextFile.txt", null);
         }
     }
 }

--- a/Collibri.Tests/Models/Files/FileRepositoryTests.cs
+++ b/Collibri.Tests/Models/Files/FileRepositoryTests.cs
@@ -76,8 +76,7 @@ namespace Collibri.Tests.Models.Files
             string updatedName, File? expected)
         {
             // Arrange
-            var path = new DirectoryInfo(
-                $@"{Directory.GetParent(Directory.GetCurrentDirectory())}\Collibri\Data\Files\{postId}\").FullName;
+            var path = FileTestHelper.GetPath(postId);
             var fileRepository = new FileRepository(fileSystem.FileSystem);
             
             // Act

--- a/Collibri.Tests/Models/Files/FileTestHelper.cs
+++ b/Collibri.Tests/Models/Files/FileTestHelper.cs
@@ -8,7 +8,8 @@ namespace Collibri.Tests.Models.Files
 	{
 		public static FileStreamResult CreateTestFileStreamResult(MockFileSystem fileSystem, string path, string fileName)
 		{
-			var fileStream = fileSystem.FileStream.New(path + "\\" + fileName, FileMode.Open, FileAccess.Read);
+			var fileStream = fileSystem.FileStream.New(
+				path + Path.DirectorySeparatorChar + fileName, FileMode.Open, FileAccess.Read);
 			return new FileStreamResult(fileStream, "application/octet-stream");
 		}
         
@@ -25,8 +26,9 @@ namespace Collibri.Tests.Models.Files
 
 		public static string GetPath(string postId)
 		{
-			return new DirectoryInfo($@"{Directory.GetParent(
-				Directory.GetCurrentDirectory())}\Collibri\Data\Files\{postId}").FullName;
+			return new DirectoryInfo(Path.Combine(
+						Directory.GetParent(Directory.GetCurrentDirectory()).FullName, 
+						"Collibri", "Data", "Files", postId)).FullName;
 		}
         
 		public static bool StreamEquals(Stream a, Stream b)

--- a/Collibri/Models/Files/File.cs
+++ b/Collibri/Models/Files/File.cs
@@ -6,30 +6,16 @@ namespace Collibri.Models.Files
 	/// </summary>
 	public class File
 	{
-		private string _name;
-		private string _path;
-		private Guid _postId;
+		public string Name { get; }
 
+		public string Path { get; }
+
+		public Guid PostId { get; }
 		public File(string path, Guid postId)
 		{
-			_path = path;
-			_name = path.Substring(path.LastIndexOf('\\') + 1);
-			_postId = postId;
-		}
-
-		public string Name
-		{
-			get { return _name; }
-		}
-
-		public string Path
-		{
-			get { return _path; }
-		}
-
-		public Guid PostId
-		{
-			get { return _postId; }
+			Path = path;
+			Name = path.Substring(path.LastIndexOf(System.IO.Path.DirectorySeparatorChar) + 1);
+			PostId = postId;
 		}
 	}
 }

--- a/Collibri/Models/Files/FileRepository.cs
+++ b/Collibri/Models/Files/FileRepository.cs
@@ -13,65 +13,75 @@ namespace Collibri.Models.Files
 		
 		public File? CreateFile(IFormFile file, string postId)
 		{
-			var path = _fileSystem.DirectoryInfo.New(
-				$@"{_fileSystem.Directory.GetParent(Directory.GetCurrentDirectory())}\Collibri\Data\Files\{postId}").FullName;
-
+			var path = GetPath(postId);
+			var separator = _fileSystem.Path.DirectorySeparatorChar;
+			
 			if (!_fileSystem.Directory.Exists(path))
 			{
 				_fileSystem.Directory.CreateDirectory(path);
 			}
 		
-			if (_fileSystem.File.Exists(path + "\\" + file.FileName))
+			if (_fileSystem.File.Exists(path + separator + file.FileName))
 			{
 				return null;
 			}
 
-			using (var fileStream = _fileSystem.File.Create(path + "\\" + file.FileName))
+			using (var fileStream = _fileSystem.File.Create(path + separator + file.FileName))
 			{
 				file.CopyTo(fileStream);
 			}
-			return (File?) new File(path + "\\" + file.FileName, Guid.Parse(postId));
+			return (File?) new File(path + separator + file.FileName, Guid.Parse(postId));
 		}
 
 		public File? DeleteFile(string fileName, string postId)
 		{
-			var path = _fileSystem.DirectoryInfo.New(
-				$@"{_fileSystem.Directory.GetParent(Directory.GetCurrentDirectory())}\Collibri\Data\Files\{postId}").FullName;
+			var path = GetPath(postId);
+			var separator = _fileSystem.Path.DirectorySeparatorChar;
 		
-			if (!_fileSystem.File.Exists(path + "\\" + fileName))
+			if (!_fileSystem.File.Exists(path + separator + fileName))
 			{
 				return null;
 			}
-			_fileSystem.File.Delete(path + "\\" + fileName);
+			_fileSystem.File.Delete(path + separator + fileName);
 			
-			return (File?) new File(path + "\\" + fileName, Guid.Parse(postId));
+			return (File?) new File(path + separator + fileName, Guid.Parse(postId));
 		}
 
 		public FileStreamResult? GetFile(string fileName, string postId)
 		{
-			var path = _fileSystem.DirectoryInfo.New(
-				$@"{_fileSystem.Directory.GetParent(Directory.GetCurrentDirectory())}\Collibri\Data\Files\{postId}").FullName;
+			var path = GetPath(postId);
+			var separator = _fileSystem.Path.DirectorySeparatorChar;
 
-			if (!_fileSystem.File.Exists(path + "\\" + fileName))
+			if (!_fileSystem.File.Exists(path + separator + fileName))
 			{
 				return null;
 			}
 
-			var fileStream = _fileSystem.FileStream.New(path + "\\" + fileName, FileMode.Open, FileAccess.Read);
+			var fileStream = _fileSystem.FileStream.New(path + separator + fileName, FileMode.Open, FileAccess.Read);
 			return new FileStreamResult(fileStream, "application/octet-stream");
 		}
 
 		public File? UpdateFileName(string fileName, string postId, string updatedName)
 		{
-			var path = _fileSystem.DirectoryInfo.New(
-				$@"{_fileSystem.Directory.GetParent(Directory.GetCurrentDirectory())}\Collibri\Data\Files\{postId}").FullName;
+			var path = GetPath(postId);
+			var separator = _fileSystem.Path.DirectorySeparatorChar;
 		
-			if (!_fileSystem.File.Exists(path + "\\" + fileName) || _fileSystem.File.Exists(path + "\\" + updatedName))
+			if (!_fileSystem.File.Exists(path + separator + fileName) || 
+			    _fileSystem.File.Exists(path + separator + updatedName))
 			{
 				return null;
 			}
-			_fileSystem.File.Move(path + "\\" + fileName, path + "\\" + updatedName);
-			return (File?) new File(path + "\\" + updatedName, Guid.Parse(postId));
+			_fileSystem.File.Move(path + separator + fileName, path + separator + updatedName);
+			return (File?) new File(path + separator + updatedName, Guid.Parse(postId));
+		}
+
+		private string GetPath(string postId)
+		{
+			return _fileSystem.DirectoryInfo.New(
+					_fileSystem.Path.Combine(
+						_fileSystem.Directory.GetParent(Directory.GetCurrentDirectory()).FullName, 
+						"Collibri", "Data", "Files", postId))
+				.FullName;
 		}
 	}
 }


### PR DESCRIPTION
Pakeičiau path FileRepository ir testuose, kad tiktų visoms platformoms.

Iškėliau path kūrimą FileRepository kiekvienam metode į atskirą private metodą GetPath().

File klasėj kintamuosius paverčiau tiesiog į fieldus su get.